### PR TITLE
Added StringComparer.InvariantCultureIgnoreCase to ProgramPaths

### DIFF
--- a/CleanUI/CleanUI/MainWindow.xaml.cs
+++ b/CleanUI/CleanUI/MainWindow.xaml.cs
@@ -38,7 +38,7 @@ namespace CleanUI
         private int MatchIndex = 0;
         private bool MultipleAutocompleteOptions = false;
         private List<String> ProgramList = new List<String>();
-        private Dictionary<String, String> ProgramPaths = new Dictionary<String, String>();
+        private Dictionary<String, String> ProgramPaths = new Dictionary<String, String>(StringComparer.InvariantCultureIgnoreCase);
         private bool recentLaunch = false;
         /*
          *  recentLaunch var is being used to a strange event that kept happening: 


### PR DESCRIPTION
This change will allow applications to be run without needing to be case-sensitive (eg. "steam" currently is an error, while "Steam" will run the Steam app)